### PR TITLE
fix extra comma, might be breaking NPM install

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "http://github.com/jonashuckestein/node-facebook-session-cookie.git",
+            "url": "http://github.com/jonashuckestein/node-facebook-session-cookie.git"
         }
     ],
     "main": "./facebook-session-cookie",


### PR DESCRIPTION
removed extraneous comma after `"url": "http://github.com/jonashuckestein/node-facebook-session-cookie.git"`
